### PR TITLE
Adicionado mais 2 Valores para indicação do Frete

### DIFF
--- a/src/FiscalBr.Common/Enums.cs
+++ b/src/FiscalBr.Common/Enums.cs
@@ -878,6 +878,8 @@ namespace FiscalBr.Common
         [DefaultValue("0")] ContaEmitente = 0,
         [DefaultValue("1")] ContaDestinatarioRemetente = 1,
         [DefaultValue("2")] ContaTerceiros = 2,
+        [DefaultValue("3")] ProprioContaRemetente = 3,
+        [DefaultValue("4")] ProprioContaDestinatario = 4,
         [DefaultValue("9")] SemCobrancaFrete = 9
     }
 

--- a/src/FiscalBr.EFDFiscal/BlocoC.cs
+++ b/src/FiscalBr.EFDFiscal/BlocoC.cs
@@ -664,6 +664,120 @@ namespace FiscalBr.EFDFiscal
                     .ComValorCofinsSt(vlCofinsSt);
             }
 
+            public static RegistroC100 PreencherDFeDeCompraAVistaComFreteProprioPorContaDoRemetente(
+                IndCodMod codModelo,
+                string numDoc,
+                string numSerie,
+                string chaveDfe,
+                DateTime dtDoc,
+                DateTime dtEntrada,
+                decimal vlDoc,
+                string codPart,
+                decimal vlMerc = 0M,
+                decimal vlDesc = 0M,
+                decimal vlAbat = 0M,
+                decimal vlFrete = 0M,
+                decimal vlSeguro = 0M,
+                decimal vlDespesas = 0M,
+                decimal vlBaseIcms = 0M,
+                decimal vlIcms = 0M,
+                decimal vlBaseIcmsSt = 0M,
+                decimal vlIcmsSt = 0M,
+                decimal vlIpi = 0M,
+                decimal vlPis = 0M,
+                decimal vlCofins = 0M,
+                decimal vlPisSt = 0M,
+                decimal vlCofinsSt = 0M
+                )
+            {
+                return new RegistroC100()
+                    .ComTipoOperacao(IndTipoOperacaoProduto.Entrada)
+                    .ComTipoEmissao(IndEmitente.Terceiros)
+                    .ComCodigoParticipante(codPart)
+                    .ComCodigoModelo(codModelo)
+                    .ComCodigoSituacao(IndCodSitDoc.DocumentoRegular)
+                    .ComSerie(numSerie)
+                    .ComNumeroDocumento(numDoc)
+                    .ComChaveDfe(chaveDfe)
+                    .ComDataEmissao(dtDoc)
+                    .ComDataEntradaSaida(dtEntrada)
+                    .ComValorTotal(vlDoc)
+                    .ComTipoPagamento(IndTipoPagamento.AVista)
+                    .ComValorDesconto(vlDesc)
+                    .ComValorAbatimento(vlAbat)
+                    .ComValorMercadorias(vlMerc)
+                    .ComTipoFrete(IndTipoFrete.ProprioContaRemetente)
+                    .ComValorFrete(vlFrete)
+                    .ComValorSeguro(vlSeguro)
+                    .ComValorOutrasDesp(vlDespesas)
+                    .ComValorBaseIcms(vlBaseIcms)
+                    .ComValorIcms(vlIcms)
+                    .ComValorBaseIcmsSt(vlBaseIcmsSt)
+                    .ComValorIcmsSt(vlIcmsSt)
+                    .ComValorIpi(vlIpi)
+                    .ComValorPis(vlPis)
+                    .ComValorCofins(vlCofins)
+                    .ComValorPisSt(vlPisSt)
+                    .ComValorCofinsSt(vlCofinsSt);
+            }
+
+            public static RegistroC100 PreencherDFeDeVendaAVistaComFreteProprioPorContaDoRemetente(
+                IndCodMod codModelo,
+                string numDoc,
+                string numSerie,
+                string chaveDfe,
+                DateTime dtDoc,
+                DateTime dtEntrada,
+                decimal vlDoc,
+                string codPart = "",
+                decimal vlMerc = 0M,
+                decimal vlDesc = 0M,
+                decimal vlAbat = 0M,
+                decimal vlFrete = 0M,
+                decimal vlSeguro = 0M,
+                decimal vlDespesas = 0M,
+                decimal vlBaseIcms = 0M,
+                decimal vlIcms = 0M,
+                decimal vlBaseIcmsSt = 0M,
+                decimal vlIcmsSt = 0M,
+                decimal vlIpi = 0M,
+                decimal vlPis = 0M,
+                decimal vlCofins = 0M,
+                decimal vlPisSt = 0M,
+                decimal vlCofinsSt = 0M
+                )
+            {
+                return new RegistroC100()
+                    .ComTipoOperacao(IndTipoOperacaoProduto.Saida)
+                    .ComTipoEmissao(IndEmitente.EmissaoPropria)
+                    .ComCodigoParticipante(codPart)
+                    .ComCodigoModelo(codModelo)
+                    .ComCodigoSituacao(IndCodSitDoc.DocumentoRegular)
+                    .ComSerie(numSerie)
+                    .ComNumeroDocumento(numDoc)
+                    .ComChaveDfe(chaveDfe)
+                    .ComDataEmissao(dtDoc)
+                    .ComDataEntradaSaida(dtEntrada)
+                    .ComValorTotal(vlDoc)
+                    .ComTipoPagamento(IndTipoPagamento.AVista)
+                    .ComValorDesconto(vlDesc)
+                    .ComValorAbatimento(vlAbat)
+                    .ComValorMercadorias(vlMerc)
+                    .ComTipoFrete(IndTipoFrete.ProprioContaRemetente)
+                    .ComValorFrete(vlFrete)
+                    .ComValorSeguro(vlSeguro)
+                    .ComValorOutrasDesp(vlDespesas)
+                    .ComValorBaseIcms(vlBaseIcms)
+                    .ComValorIcms(vlIcms)
+                    .ComValorBaseIcmsSt(vlBaseIcmsSt)
+                    .ComValorIcmsSt(vlIcmsSt)
+                    .ComValorIpi(vlIpi)
+                    .ComValorPis(vlPis)
+                    .ComValorCofins(vlCofins)
+                    .ComValorPisSt(vlPisSt)
+                    .ComValorCofinsSt(vlCofinsSt);
+            }
+
             public static RegistroC100 PreencherDFeDeCompraAVistaComFretePorContaDoDestinatario(
                 IndCodMod codModelo,
                 string numDoc,
@@ -764,6 +878,120 @@ namespace FiscalBr.EFDFiscal
                     .ComValorAbatimento(vlAbat)
                     .ComValorMercadorias(vlMerc)
                     .ComTipoFrete(IndTipoFrete.ContaDestinatarioRemetente)
+                    .ComValorFrete(vlFrete)
+                    .ComValorSeguro(vlSeguro)
+                    .ComValorOutrasDesp(vlDespesas)
+                    .ComValorBaseIcms(vlBaseIcms)
+                    .ComValorIcms(vlIcms)
+                    .ComValorBaseIcmsSt(vlBaseIcmsSt)
+                    .ComValorIcmsSt(vlIcmsSt)
+                    .ComValorIpi(vlIpi)
+                    .ComValorPis(vlPis)
+                    .ComValorCofins(vlCofins)
+                    .ComValorPisSt(vlPisSt)
+                    .ComValorCofinsSt(vlCofinsSt);
+            }
+
+            public static RegistroC100 PreencherDFeDeCompraAVistaComFreteProprioPorContaDoDestinatario(
+                IndCodMod codModelo,
+                string numDoc,
+                string numSerie,
+                string chaveDfe,
+                DateTime dtDoc,
+                DateTime dtEntrada,
+                decimal vlDoc,
+                string codPart,
+                decimal vlMerc = 0M,
+                decimal vlDesc = 0M,
+                decimal vlAbat = 0M,
+                decimal vlFrete = 0M,
+                decimal vlSeguro = 0M,
+                decimal vlDespesas = 0M,
+                decimal vlBaseIcms = 0M,
+                decimal vlIcms = 0M,
+                decimal vlBaseIcmsSt = 0M,
+                decimal vlIcmsSt = 0M,
+                decimal vlIpi = 0M,
+                decimal vlPis = 0M,
+                decimal vlCofins = 0M,
+                decimal vlPisSt = 0M,
+                decimal vlCofinsSt = 0M
+                )
+            {
+                return new RegistroC100()
+                    .ComTipoOperacao(IndTipoOperacaoProduto.Entrada)
+                    .ComTipoEmissao(IndEmitente.Terceiros)
+                    .ComCodigoParticipante(codPart)
+                    .ComCodigoModelo(codModelo)
+                    .ComCodigoSituacao(IndCodSitDoc.DocumentoRegular)
+                    .ComSerie(numSerie)
+                    .ComNumeroDocumento(numDoc)
+                    .ComChaveDfe(chaveDfe)
+                    .ComDataEmissao(dtDoc)
+                    .ComDataEntradaSaida(dtEntrada)
+                    .ComValorTotal(vlDoc)
+                    .ComTipoPagamento(IndTipoPagamento.AVista)
+                    .ComValorDesconto(vlDesc)
+                    .ComValorAbatimento(vlAbat)
+                    .ComValorMercadorias(vlMerc)
+                    .ComTipoFrete(IndTipoFrete.ProprioContaDestinatario)
+                    .ComValorFrete(vlFrete)
+                    .ComValorSeguro(vlSeguro)
+                    .ComValorOutrasDesp(vlDespesas)
+                    .ComValorBaseIcms(vlBaseIcms)
+                    .ComValorIcms(vlIcms)
+                    .ComValorBaseIcmsSt(vlBaseIcmsSt)
+                    .ComValorIcmsSt(vlIcmsSt)
+                    .ComValorIpi(vlIpi)
+                    .ComValorPis(vlPis)
+                    .ComValorCofins(vlCofins)
+                    .ComValorPisSt(vlPisSt)
+                    .ComValorCofinsSt(vlCofinsSt);
+            }
+
+            public static RegistroC100 PreencherDFeDeVendaAVistaComFreteProprioPorContaDoDestinatario(
+                IndCodMod codModelo,
+                string numDoc,
+                string numSerie,
+                string chaveDfe,
+                DateTime dtDoc,
+                DateTime dtEntrada,
+                decimal vlDoc,
+                string codPart = "",
+                decimal vlMerc = 0M,
+                decimal vlDesc = 0M,
+                decimal vlAbat = 0M,
+                decimal vlFrete = 0M,
+                decimal vlSeguro = 0M,
+                decimal vlDespesas = 0M,
+                decimal vlBaseIcms = 0M,
+                decimal vlIcms = 0M,
+                decimal vlBaseIcmsSt = 0M,
+                decimal vlIcmsSt = 0M,
+                decimal vlIpi = 0M,
+                decimal vlPis = 0M,
+                decimal vlCofins = 0M,
+                decimal vlPisSt = 0M,
+                decimal vlCofinsSt = 0M
+                )
+            {
+                return new RegistroC100()
+                    .ComTipoOperacao(IndTipoOperacaoProduto.Saida)
+                    .ComTipoEmissao(IndEmitente.EmissaoPropria)
+                    .ComCodigoParticipante(codPart)
+                    .ComCodigoModelo(codModelo)
+                    .ComCodigoSituacao(IndCodSitDoc.DocumentoRegular)
+                    .ComSerie(numSerie)
+                    .ComNumeroDocumento(numDoc)
+                    .ComChaveDfe(chaveDfe)
+                    .ComDataEmissao(dtDoc)
+                    .ComDataEntradaSaida(dtEntrada)
+                    .ComValorTotal(vlDoc)
+                    .ComTipoPagamento(IndTipoPagamento.AVista)
+                    .ComValorDesconto(vlDesc)
+                    .ComValorAbatimento(vlAbat)
+                    .ComValorMercadorias(vlMerc)
+                    .ComTipoFrete(IndTipoFrete.ProprioContaDestinatario)
                     .ComValorFrete(vlFrete)
                     .ComValorSeguro(vlSeguro)
                     .ComValorOutrasDesp(vlDespesas)
@@ -1004,6 +1232,120 @@ namespace FiscalBr.EFDFiscal
                     .ComValorCofinsSt(vlCofinsSt);
             }
 
+            public static RegistroC100 PreencherDFeDeCompraAPrazoComFreteProprioPorContaDoRemetente(
+                IndCodMod codModelo,
+                string numDoc,
+                string numSerie,
+                string chaveDfe,
+                DateTime dtDoc,
+                DateTime dtEntrada,
+                decimal vlDoc,
+                string codPart,
+                decimal vlMerc = 0M,
+                decimal vlDesc = 0M,
+                decimal vlAbat = 0M,
+                decimal vlFrete = 0M,
+                decimal vlSeguro = 0M,
+                decimal vlDespesas = 0M,
+                decimal vlBaseIcms = 0M,
+                decimal vlIcms = 0M,
+                decimal vlBaseIcmsSt = 0M,
+                decimal vlIcmsSt = 0M,
+                decimal vlIpi = 0M,
+                decimal vlPis = 0M,
+                decimal vlCofins = 0M,
+                decimal vlPisSt = 0M,
+                decimal vlCofinsSt = 0M
+                )
+            {
+                return new RegistroC100()
+                    .ComTipoOperacao(IndTipoOperacaoProduto.Entrada)
+                    .ComTipoEmissao(IndEmitente.Terceiros)
+                    .ComCodigoParticipante(codPart)
+                    .ComCodigoModelo(codModelo)
+                    .ComCodigoSituacao(IndCodSitDoc.DocumentoRegular)
+                    .ComSerie(numSerie)
+                    .ComNumeroDocumento(numDoc)
+                    .ComChaveDfe(chaveDfe)
+                    .ComDataEmissao(dtDoc)
+                    .ComDataEntradaSaida(dtEntrada)
+                    .ComValorTotal(vlDoc)
+                    .ComTipoPagamento(IndTipoPagamento.APrazo)
+                    .ComValorDesconto(vlDesc)
+                    .ComValorAbatimento(vlAbat)
+                    .ComValorMercadorias(vlMerc)
+                    .ComTipoFrete(IndTipoFrete.ProprioContaRemetente)
+                    .ComValorFrete(vlFrete)
+                    .ComValorSeguro(vlSeguro)
+                    .ComValorOutrasDesp(vlDespesas)
+                    .ComValorBaseIcms(vlBaseIcms)
+                    .ComValorIcms(vlIcms)
+                    .ComValorBaseIcmsSt(vlBaseIcmsSt)
+                    .ComValorIcmsSt(vlIcmsSt)
+                    .ComValorIpi(vlIpi)
+                    .ComValorPis(vlPis)
+                    .ComValorCofins(vlCofins)
+                    .ComValorPisSt(vlPisSt)
+                    .ComValorCofinsSt(vlCofinsSt);
+            }
+
+            public static RegistroC100 PreencherDFeDeVendaAPrazoComFreteProprioPorContaDoRemetente(
+                IndCodMod codModelo,
+                string numDoc,
+                string numSerie,
+                string chaveDfe,
+                DateTime dtDoc,
+                DateTime dtEntrada,
+                decimal vlDoc,
+                string codPart = "",
+                decimal vlMerc = 0M,
+                decimal vlDesc = 0M,
+                decimal vlAbat = 0M,
+                decimal vlFrete = 0M,
+                decimal vlSeguro = 0M,
+                decimal vlDespesas = 0M,
+                decimal vlBaseIcms = 0M,
+                decimal vlIcms = 0M,
+                decimal vlBaseIcmsSt = 0M,
+                decimal vlIcmsSt = 0M,
+                decimal vlIpi = 0M,
+                decimal vlPis = 0M,
+                decimal vlCofins = 0M,
+                decimal vlPisSt = 0M,
+                decimal vlCofinsSt = 0M
+                )
+            {
+                return new RegistroC100()
+                    .ComTipoOperacao(IndTipoOperacaoProduto.Saida)
+                    .ComTipoEmissao(IndEmitente.EmissaoPropria)
+                    .ComCodigoParticipante(codPart)
+                    .ComCodigoModelo(codModelo)
+                    .ComCodigoSituacao(IndCodSitDoc.DocumentoRegular)
+                    .ComSerie(numSerie)
+                    .ComNumeroDocumento(numDoc)
+                    .ComChaveDfe(chaveDfe)
+                    .ComDataEmissao(dtDoc)
+                    .ComDataEntradaSaida(dtEntrada)
+                    .ComValorTotal(vlDoc)
+                    .ComTipoPagamento(IndTipoPagamento.APrazo)
+                    .ComValorDesconto(vlDesc)
+                    .ComValorAbatimento(vlAbat)
+                    .ComValorMercadorias(vlMerc)
+                    .ComTipoFrete(IndTipoFrete.ProprioContaRemetente)
+                    .ComValorFrete(vlFrete)
+                    .ComValorSeguro(vlSeguro)
+                    .ComValorOutrasDesp(vlDespesas)
+                    .ComValorBaseIcms(vlBaseIcms)
+                    .ComValorIcms(vlIcms)
+                    .ComValorBaseIcmsSt(vlBaseIcmsSt)
+                    .ComValorIcmsSt(vlIcmsSt)
+                    .ComValorIpi(vlIpi)
+                    .ComValorPis(vlPis)
+                    .ComValorCofins(vlCofins)
+                    .ComValorPisSt(vlPisSt)
+                    .ComValorCofinsSt(vlCofinsSt);
+            }
+
             public static RegistroC100 PreencherDFeDeCompraAPrazoComFretePorContaDoDestinatario(
                 IndCodMod codModelo,
                 string numDoc,
@@ -1104,6 +1446,120 @@ namespace FiscalBr.EFDFiscal
                     .ComValorAbatimento(vlAbat)
                     .ComValorMercadorias(vlMerc)
                     .ComTipoFrete(IndTipoFrete.ContaDestinatarioRemetente)
+                    .ComValorFrete(vlFrete)
+                    .ComValorSeguro(vlSeguro)
+                    .ComValorOutrasDesp(vlDespesas)
+                    .ComValorBaseIcms(vlBaseIcms)
+                    .ComValorIcms(vlIcms)
+                    .ComValorBaseIcmsSt(vlBaseIcmsSt)
+                    .ComValorIcmsSt(vlIcmsSt)
+                    .ComValorIpi(vlIpi)
+                    .ComValorPis(vlPis)
+                    .ComValorCofins(vlCofins)
+                    .ComValorPisSt(vlPisSt)
+                    .ComValorCofinsSt(vlCofinsSt);
+            }
+
+            public static RegistroC100 PreencherDFeDeCompraAPrazoComFreteProprioPorContaDoDestinatario(
+                IndCodMod codModelo,
+                string numDoc,
+                string numSerie,
+                string chaveDfe,
+                DateTime dtDoc,
+                DateTime dtEntrada,
+                decimal vlDoc,
+                string codPart,
+                decimal vlMerc = 0M,
+                decimal vlDesc = 0M,
+                decimal vlAbat = 0M,
+                decimal vlFrete = 0M,
+                decimal vlSeguro = 0M,
+                decimal vlDespesas = 0M,
+                decimal vlBaseIcms = 0M,
+                decimal vlIcms = 0M,
+                decimal vlBaseIcmsSt = 0M,
+                decimal vlIcmsSt = 0M,
+                decimal vlIpi = 0M,
+                decimal vlPis = 0M,
+                decimal vlCofins = 0M,
+                decimal vlPisSt = 0M,
+                decimal vlCofinsSt = 0M
+                )
+            {
+                return new RegistroC100()
+                    .ComTipoOperacao(IndTipoOperacaoProduto.Entrada)
+                    .ComTipoEmissao(IndEmitente.Terceiros)
+                    .ComCodigoParticipante(codPart)
+                    .ComCodigoModelo(codModelo)
+                    .ComCodigoSituacao(IndCodSitDoc.DocumentoRegular)
+                    .ComSerie(numSerie)
+                    .ComNumeroDocumento(numDoc)
+                    .ComChaveDfe(chaveDfe)
+                    .ComDataEmissao(dtDoc)
+                    .ComDataEntradaSaida(dtEntrada)
+                    .ComValorTotal(vlDoc)
+                    .ComTipoPagamento(IndTipoPagamento.APrazo)
+                    .ComValorDesconto(vlDesc)
+                    .ComValorAbatimento(vlAbat)
+                    .ComValorMercadorias(vlMerc)
+                    .ComTipoFrete(IndTipoFrete.ProprioContaDestinatario)
+                    .ComValorFrete(vlFrete)
+                    .ComValorSeguro(vlSeguro)
+                    .ComValorOutrasDesp(vlDespesas)
+                    .ComValorBaseIcms(vlBaseIcms)
+                    .ComValorIcms(vlIcms)
+                    .ComValorBaseIcmsSt(vlBaseIcmsSt)
+                    .ComValorIcmsSt(vlIcmsSt)
+                    .ComValorIpi(vlIpi)
+                    .ComValorPis(vlPis)
+                    .ComValorCofins(vlCofins)
+                    .ComValorPisSt(vlPisSt)
+                    .ComValorCofinsSt(vlCofinsSt);
+            }
+
+            public static RegistroC100 PreencherDFeDeVendaAPrazoComFreteProprioPorContaDoDestinatario(
+                IndCodMod codModelo,
+                string numDoc,
+                string numSerie,
+                string chaveDfe,
+                DateTime dtDoc,
+                DateTime dtEntrada,
+                decimal vlDoc,
+                string codPart = "",
+                decimal vlMerc = 0M,
+                decimal vlDesc = 0M,
+                decimal vlAbat = 0M,
+                decimal vlFrete = 0M,
+                decimal vlSeguro = 0M,
+                decimal vlDespesas = 0M,
+                decimal vlBaseIcms = 0M,
+                decimal vlIcms = 0M,
+                decimal vlBaseIcmsSt = 0M,
+                decimal vlIcmsSt = 0M,
+                decimal vlIpi = 0M,
+                decimal vlPis = 0M,
+                decimal vlCofins = 0M,
+                decimal vlPisSt = 0M,
+                decimal vlCofinsSt = 0M
+                )
+            {
+                return new RegistroC100()
+                    .ComTipoOperacao(IndTipoOperacaoProduto.Saida)
+                    .ComTipoEmissao(IndEmitente.EmissaoPropria)
+                    .ComCodigoParticipante(codPart)
+                    .ComCodigoModelo(codModelo)
+                    .ComCodigoSituacao(IndCodSitDoc.DocumentoRegular)
+                    .ComSerie(numSerie)
+                    .ComNumeroDocumento(numDoc)
+                    .ComChaveDfe(chaveDfe)
+                    .ComDataEmissao(dtDoc)
+                    .ComDataEntradaSaida(dtEntrada)
+                    .ComValorTotal(vlDoc)
+                    .ComTipoPagamento(IndTipoPagamento.APrazo)
+                    .ComValorDesconto(vlDesc)
+                    .ComValorAbatimento(vlAbat)
+                    .ComValorMercadorias(vlMerc)
+                    .ComTipoFrete(IndTipoFrete.ProprioContaDestinatario)
                     .ComValorFrete(vlFrete)
                     .ComValorSeguro(vlSeguro)
                     .ComValorOutrasDesp(vlDespesas)

--- a/tests/FiscalBr.Test/Sped/SpedEnumTest.cs
+++ b/tests/FiscalBr.Test/Sped/SpedEnumTest.cs
@@ -30,6 +30,8 @@ namespace FiscalBr.Test.Sped
         [InlineData(IndTipoFrete.ContaEmitente)]
         [InlineData(IndTipoFrete.ContaDestinatarioRemetente)]
         [InlineData(IndTipoFrete.ContaTerceiros)]
+        [InlineData(IndTipoFrete.ProprioContaRemetente)]
+        [InlineData(IndTipoFrete.ProprioContaDestinatario)]
         [InlineData(IndTipoFrete.SemCobrancaFrete)]
         public void IndTipoFreteTest(IndTipoFrete v)
         {


### PR DESCRIPTION
3 - Transporte Próprio por conta do Remetente;
4 - Transporte Próprio por conta do Destinatário;

Obs.: Nomenclatura dos Enuns que já existiam, não foi alterada.

**Descrição:**
Obs: A partir de 01/01/2018 passará a ser:
Indicador do tipo de frete:
0 - Contratação do Frete por conta do Remetente (CIF);
1 - Contratação do Frete por conta do Destinatário (FOB);
2 - Contratação do Frete por conta de Terceiros;
3 - Transporte Próprio por conta do Remetente;
4 - Transporte Próprio por conta do Destinatário;
9 - Sem Ocorrência de Transporte.

**Check list:**
- [ ] Marque se alterações na Wiki do projeto serão necessárias.
- [X] Marque se os testes foram adicionados e/ou atualizados após as alterações.