### PR TITLE
Fixes Leitura Bloco1

### DIFF
--- a/src/FiscalBr.Common/Sped/LerCamposSped.cs
+++ b/src/FiscalBr.Common/Sped/LerCamposSped.cs
@@ -56,7 +56,10 @@ namespace FiscalBr.Common.Sped
                     {
                         int convertedInt32Value;
                         conversionResult = Int32.TryParse(value.ToStringSafe(), out convertedInt32Value);
-                        prop.SetValue(instantiatedObject, convertedInt32Value);
+                        if (propType == typeof(Nullable<Int64>))
+                            prop.SetValue(instantiatedObject, (Nullable<Int64>)convertedInt32Value);
+                        else
+                            prop.SetValue(instantiatedObject, convertedInt32Value);
                     }
 
                     else if (propType == typeof(DateTime) || propType == typeof(Nullable<DateTime>))

--- a/src/FiscalBr.Common/Sped/LerCamposSped.cs
+++ b/src/FiscalBr.Common/Sped/LerCamposSped.cs
@@ -107,6 +107,16 @@ namespace FiscalBr.Common.Sped
                         conversionResult = Decimal.TryParse(value.ToStringSafe(), out convertedDecimalValue);
                         prop.SetValue(instantiatedObject, convertedDecimalValue);
                     }
+                    else if (propType == typeof(Double) || propType == typeof(Nullable<Double>))
+                    {
+                        Double convertedDoubleValue;
+                        conversionResult = Double.TryParse(value.ToStringSafe(), out convertedDoubleValue);
+                        prop.SetValue(instantiatedObject, convertedDoubleValue);
+                        if (propType == typeof(Nullable<Double>))
+                            prop.SetValue(instantiatedObject, (Nullable<Double>)convertedDoubleValue);
+                        else
+                            prop.SetValue(instantiatedObject, convertedDoubleValue);
+                    }
                     else if (propType == typeof(Int32) || propType == typeof(Nullable<Int32>))
                     {
                         int convertedInt32Value;

--- a/src/FiscalBr.EFDFiscal/ArquivoEFDFiscal.cs
+++ b/src/FiscalBr.EFDFiscal/ArquivoEFDFiscal.cs
@@ -492,10 +492,10 @@ namespace FiscalBr.EFDFiscal
                 case "1923":
                     reg1921 = Bloco1.Reg1001.Reg1900s.Last().Reg1910s.Last().Reg1920.Reg1921s.Last();
 
-                    if (reg1921.Reg1922s == null)
-                        reg1921.Reg1922s = new List<Bloco1.Registro1922>();
+                    if (reg1921.Reg1923s == null)
+                        reg1921.Reg1923s = new List<Bloco1.Registro1923>();
 
-                    reg1921.Reg1922s.Add((Bloco1.Registro1922)registro);
+                    reg1921.Reg1923s.Add((Bloco1.Registro1923)registro);
                     break;
 
                 case "1925":
@@ -657,8 +657,8 @@ namespace FiscalBr.EFDFiscal
                 BlocoC = new BlocoC();
 
                 /*
-                * Cria o C001 com movimento caso não exista no arquivo,
-                * isso é feito para os cenários onde será realizada a
+                * Cria o C001 com movimento caso nï¿½o exista no arquivo,
+                * isso ï¿½ feito para os cenï¿½rios onde serï¿½ realizada a
                 * leitura isolada somente de alguns registros do Bloco C.
                 */
                 if (BlocoC.RegC001 == null)
@@ -2050,10 +2050,10 @@ namespace FiscalBr.EFDFiscal
             base.CalcularBloco9(totalizarblocos);
 
             #region Totalizar blocos
-            if (totalizarblocos) //Calcula os X990 de todos os blocos e readiciona as linhas de totalização -> |X990|
+            if (totalizarblocos) //Calcula os X990 de todos os blocos e readiciona as linhas de totalizaï¿½ï¿½o -> |X990|
             {
                 var registros = Linhas
-                    .Where(x => x.Length > 6 && x.Substring(2, 3) != "990") // Pega só as linhas que não se tratam de totalizadores
+                    .Where(x => x.Length > 6 && x.Substring(2, 3) != "990") // Pega sï¿½ as linhas que nï¿½o se tratam de totalizadores
                     .Select(x => x.Substring(1, 4));
 
                 if (Bloco0 != null)
@@ -2088,7 +2088,7 @@ namespace FiscalBr.EFDFiscal
             #endregion
 
             #region Bloco 9
-            Linhas.RemoveAll(x => x.Length > 6 && x[1] == '9'); //Remove todas as linhas do Bloco 9, as linhas serão readicionadas posteriormente
+            Linhas.RemoveAll(x => x.Length > 6 && x[1] == '9'); //Remove todas as linhas do Bloco 9, as linhas serï¿½o readicionadas posteriormente
 
             Bloco9 = new Bloco9()
             {

--- a/tests/FiscalBr.Test/Sped/Bloco1/Bloco1Registro1320Test.cs
+++ b/tests/FiscalBr.Test/Sped/Bloco1/Bloco1Registro1320Test.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FiscalBr.Common.Sped;
+using Xunit;
+
+namespace FiscalBr.Test.Sped.Bloco1
+{
+    public class Bloco1Registro1320Test
+    {
+        [Fact]
+        public void Ler_Registro_1320_EFDFiscal()
+        {
+            string linha = "|1320|1|1234567890|Motivo 1|Interventor 1|51077662000109|00695196090|100,13|55,20|10|40|";
+             
+            var registro = (FiscalBr.EFDFiscal.Bloco1.Registro1320)LerCamposSped.LerCampos(linha, Constantes.ArquivoDigital.Sped.EFDFiscal, 0); 
+
+            Assert.Equal("1320", registro.Reg);
+            Assert.Equal(1, registro.NumBico);
+            Assert.Equal(1234567890, registro.NrInterv);
+            Assert.Equal("Motivo 1", registro.MotInterv);
+            Assert.Equal("Interventor 1", registro.NomInterv);
+            Assert.Equal("51077662000109", registro.CnpjInterv);
+            Assert.Equal("00695196090", registro.CpfInterv);
+            Assert.Equal((decimal)100.13, registro.ValFecha);
+            Assert.Equal((decimal)55.20, registro.ValAbert);
+            Assert.Equal(10, registro.VolAferi);
+            Assert.Equal(40, registro.VolVendas); 
+        }        
+    }
+}

--- a/tests/FiscalBr.Test/Sped/Bloco1/Bloco1Registro1391Test.cs
+++ b/tests/FiscalBr.Test/Sped/Bloco1/Bloco1Registro1391Test.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using FiscalBr.Common.Sped;
+
+namespace FiscalBr.Test.Sped.Bloco1
+{
+    public class Bloco1Registro1391Test
+    {
+        [Fact]
+        public void Ler_Registro_1391_EFDFiscal()
+        {
+            string linha = "|1391|01012023|123,41|123,42|123,43|123,44|123,45|123,46|123,47|123,48|123,49|123,40|123,41|123,42|123,43|123,44|Observações|COD_ITEM|01|123,45|";
+
+            var registro = (FiscalBr.EFDFiscal.Bloco1.Registro1391)LerCamposSped.LerCampos(linha, Constantes.ArquivoDigital.Sped.EFDFiscal, 0);
+
+            Assert.Equal("1391", registro.Reg);
+            Assert.Equal(new DateTime(2023, 01, 01), registro.DtRegistro);
+            Assert.Equal(123.41, registro.QtdMoid);
+            Assert.Equal(123.42, registro.EstqIni);
+            Assert.Equal(123.43, registro.QtdProduz);
+            Assert.Equal(123.44, registro.EntAnidHid);
+            Assert.Equal(123.45, registro.OutrEntr);
+            Assert.Equal(123.46, registro.Perda);
+            Assert.Equal(123.47, registro.Cons);
+            Assert.Equal(123.48, registro.SaiAniHid);
+            Assert.Equal(123.49, registro.Saidas);
+            Assert.Equal(123.40, registro.EstqFin);
+            Assert.Equal(123.41, registro.EstqIniMel);
+            Assert.Equal(123.42, registro.ProdDiaMel);
+            Assert.Equal(123.43, registro.UtilMel);
+            Assert.Equal(123.44, registro.ProdAlcMel);
+            Assert.Equal("Observações", registro.Obs);
+            Assert.Equal("COD_ITEM", registro.CodItem);
+            Assert.Equal(1, registro.TpResiduo);
+            Assert.Equal((decimal)123.45, registro.QtdResiduo);
+        }
+    }
+}

--- a/tests/FiscalBr.Test/Sped/Bloco1/Bloco1Registro1921Test.cs
+++ b/tests/FiscalBr.Test/Sped/Bloco1/Bloco1Registro1921Test.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FiscalBr.Test.Sped.Bloco1
+{
+    public class Bloco1Registro1921Test
+    {
+        [Fact]
+        public void Ler_Registro_1921_EFDFiscal()
+        {
+            //instanciar array de strings
+            string[] source = new string[7];
+            source[0] = "|1001|0|1|";
+            source[1] = "|1900|1|Descrição Complementar|";
+            source[2] = "|1910|01012023|31012023|";
+            source[3] = "|1920|1000.00|500.00|1500.00|300.00|2000.00|1000.00|500.00|500.00|200.00|3000.00|500.00|50.00|";
+            source[4] = "|1921|COD123|Descrição Complementar do Ajuste|100.00|";
+            source[5] = "|1922|123456|1234567890|1|Descrição do Processo|Texto Complementar do Ajuste|";
+            source[6] = "|1923|FornecedorA|01|123|001|987654321|01012023|Item001|100.00|";
+
+            var sped = new ArquivoEFDFiscal();
+            sped.Ler(source);
+
+            //Bloco 1
+            Assert.Equal("1900", sped.Bloco1.Reg1001.Reg1900s[0].Reg);
+            Assert.Equal("1910", sped.Bloco1.Reg1001.Reg1900s[0].Reg1910s[0].Reg);
+            Assert.Equal("1921", sped.Bloco1.Reg1001.Reg1900s[0].Reg1910s[0].Reg1920.Reg1921s[0].Reg);
+            Assert.Equal("1922", sped.Bloco1.Reg1001.Reg1900s[0].Reg1910s[0].Reg1920.Reg1921s[0].Reg1922s[0].Reg);
+            Assert.Equal("1923", sped.Bloco1.Reg1001.Reg1900s[0].Reg1910s[0].Reg1920.Reg1921s[0].Reg1923s[0].Reg);
+            
+        }
+    }
+}


### PR DESCRIPTION
**Descrição:**
- fix(bloco1): System.InvalidCastException : Unable to cast object of type 'Registro1923' to type 'Registro1922'.
estava tentando adicionar registro do tipo 1923 para a lista do registro do tipo 1922

- fix(bloco1): registro 1391 'Object of type 'System.String' cannot be converted to type System.Nullable`1[System.Double]'
propriedades Nullable do registro estão gerando essa exception

- fix(bloco1): registro 1320 'System.Int32' cannot be converted to type 'System.Nullable'
quando havia valor no campo NrInterv que é nullable do tipo long gerava essa exeption

**Check list:**
- [ ] Marque se alterações na Wiki do projeto serão necessárias.
- [x] Marque se os testes foram adicionados e/ou atualizados após as alterações.
