### PR TITLE
Alteração do Layout EFD ICMS IPI

### DIFF
--- a/src/FiscalBr.Common/Enums.cs
+++ b/src/FiscalBr.Common/Enums.cs
@@ -203,7 +203,8 @@ namespace FiscalBr.Common
         [DefaultValue("14")] V14,
         [DefaultValue("15")] V15,
         [DefaultValue("16")] V16,
-        [DefaultValue("17")] V17
+        [DefaultValue("17")] V17,
+        [DefaultValue("18")] V18
     }
 
     public enum CodVersaoSpedECD
@@ -460,6 +461,13 @@ namespace FiscalBr.Common
         /// Validade: 01/01/2023 - 31/12/2023
         /// </summary>
         [DefaultValue("017")] V17,
+
+        /// <summary>
+        /// Código: 018
+        /// Versão: 1.16
+        /// Validade: 01/01/2024 - 31/12/2024
+        /// </summary>
+        [DefaultValue("018")] V18
     }
 
     public enum SimOuNao
@@ -896,7 +904,12 @@ namespace FiscalBr.Common
         /// <summary>
         ///     1 - Leasing de veículos ou faturamento direto.
         /// </summary>
-        [DefaultValue("1")] LeasingVeiculosFaturamentoDireto
+        [DefaultValue("1")] LeasingVeiculosFaturamentoDireto,
+
+        /// <summary>
+        ///     2 - Recusa de recebimento (de acordo com as condições descritas nas instruções do Registro)
+        /// </summary>
+        [DefaultValue("2")] RecusaDeRecebimento
     }
 
     /// <summary>

--- a/src/FiscalBr.Common/Sped/ArquivoSpedV2.cs
+++ b/src/FiscalBr.Common/Sped/ArquivoSpedV2.cs
@@ -755,6 +755,8 @@ namespace FiscalBr.Common.Sped
                             return CodVersaoSpedFiscal.V16;
                         case VersaoLeiauteSped.V17:
                             return CodVersaoSpedFiscal.V17;
+                        case VersaoLeiauteSped.V18:
+                            return CodVersaoSpedFiscal.V18;
                     }
                     break;
             }

--- a/src/FiscalBr.EFDFiscal/Bloco1.cs
+++ b/src/FiscalBr.EFDFiscal/Bloco1.cs
@@ -988,6 +988,7 @@ namespace FiscalBr.EFDFiscal
             ///     01 – Bagaço de cana
             ///     02 - DDG
             ///     03 - WDG
+            ///     04 - (DDG + WDG)
             /// </remarks>
             [SpedCampos(19, "TP_RESIDUO", "N", 2, 0, false, 6)]
             public int? TpResiduo { get; set; }
@@ -995,8 +996,26 @@ namespace FiscalBr.EFDFiscal
             /// <summary>
             ///     Quantidade de resíduo produzido (toneladas)
             /// </summary>
-            [SpedCampos(19, "QTD_RESIDUO", "N", int.MaxValue, 2, true, 6)]
+            [SpedCampos(20, "QTD_RESIDUO", "N", int.MaxValue, 2, true, 6)]
             public decimal QtdResiduo { get; set; }
+
+            /// <summary>
+            ///     Quantidade de resíduo produzido de DDG (toneladas)
+            /// </summary>
+            [SpedCampos(21, "QTD_RESIDUO_DDG", "N", int.MaxValue, 2, true, 18)]
+            public decimal QtdResiduoDdg { get; set; }
+
+            /// <summary>
+            ///     Quantidade de resíduo produzido de WDG (toneladas)
+            /// </summary>
+            [SpedCampos(22, "QTD_RESIDUO_WDG", "N", int.MaxValue, 2, true, 18)]
+            public decimal QtdResiduoWdg { get; set; }
+
+            /// <summary>
+            ///     Quantidade de resíduo produzido de bagaço de cana (toneladas)
+            /// </summary>
+            [SpedCampos(23, "QTD_RESIDUO_CANA", "N", int.MaxValue, 2, true, 18)]
+            public decimal QtdResiduoCana { get; set; }
         }
 
         /// <summary>
@@ -1012,7 +1031,9 @@ namespace FiscalBr.EFDFiscal
             }
 
             /// <summary>
-            ///     Código do item - próprio IPM ou campo 02 do Registro 0200
+            ///     Código do item (Tabela 5.9.1 de Itens UF Índice de 
+            ///     Participação dos Municípios ou Tabela 5.9.2 de Itens UF_ST
+            ///     Índice de participação dos Municípios) ou campo 02 do Registro 0200
             /// </summary>
             [SpedCampos(2, "COD_ITEM_IPM", "C", 60, 0, true, 2)]
             public string CodItemIpm { get; set; }

--- a/src/FiscalBr.EFDFiscal/BlocoC.cs
+++ b/src/FiscalBr.EFDFiscal/BlocoC.cs
@@ -1278,8 +1278,8 @@ namespace FiscalBr.EFDFiscal
             /// </summary>
             /// <remarks>
             ///     0 - Combustíveis e lubrificantes;
-            ///     <para />
-            ///     1 - Leasing de veículos ou faturamento direto.
+            ///     1 - Leasing de veículos ou faturamento direto;
+            ///     2 - Recusa de recebimento (de acordo com as condições descritas nas instruções do Registro).
             /// </remarks>
             [SpedCampos(2, "OPER", "N", 1, 0, true, 3)]
             public IndTipoOperacaoStUfDiversa Oper { get; set; }
@@ -5512,7 +5512,9 @@ namespace FiscalBr.EFDFiscal
 
         /// <summary>
         ///     REGISTRO C700: CONSOLIDAÇÃO DOS DOCUMENTOS (EMPRESAS OBRIGADAS
-        ///     À ENTREGA DO ARQUIVO PREVISTO NO CONVÊNIO ICMS 115/03)
+        ///     À ENTREGA DO ARQUIVO PREVISTO NO CONVÊNIO ICMS 115/03), NOTA FISCAL/CONTA DE
+        ///     FORNECIMENTO DE GÁS CANALIZADO (CÓDIGO 28) e NOTA FISCAL DE ENERGIA
+        ///     ELÉTRICA ELETRÔNICA – NF3e (CÓDIGO 66)
         /// </summary>
         public class RegistroC700 : RegistroSped
         {

--- a/src/FiscalBr.EFDFiscal/BlocoD.cs
+++ b/src/FiscalBr.EFDFiscal/BlocoD.cs
@@ -3066,6 +3066,7 @@ namespace FiscalBr.EFDFiscal
             ///     Série do documento fiscal.
             /// </summary>
             [SpedCampos(7, "SER", "N", 3, 0, false, 17)]
+            [SpedCampos(7, "SER", "N", 3, 0, true, 18)]
             public string Ser { get; set; }
 
             /// <summary>
@@ -3081,7 +3082,7 @@ namespace FiscalBr.EFDFiscal
             public DateTime? DtDoc { get; set; }
 
             /// <summary>
-            ///     Data da entrada.
+            ///     Data da entrada ou da saída.
             /// </summary>
             [SpedCampos(10, "DT_E_S", "N", 8, 0, false, 17)]
             public DateTime? DtEs { get; set; }
@@ -3156,6 +3157,7 @@ namespace FiscalBr.EFDFiscal
             ///     Chave da Nota Fiscal Fatura de Serviço de Comunicação Eletrônica.
             /// </summary>
             [SpedCampos(22, "CHV_DOCe", "C", 44, 0, false, 17)]
+            [SpedCampos(22, "CHV_DOCe", "C", 44, 0, true, 18)]
             public string ChvDoce { get; set; }
 
             /// <summary>
@@ -3262,8 +3264,8 @@ namespace FiscalBr.EFDFiscal
             public decimal AliqIcms { get; set; }
 
             /// <summary>
-            ///     Valor total acumulado das operações correspondentes à combinação de CST_ICMS, CFOP e alíquota do ICMS, incluídas as
-            ///     despesas acessórias e acréscimos.
+            ///     Valor total dos itens relacionados aos serviços próprios, com destaque de ICMS, correspondente à
+            ///     combinação de CST_ICMS, CFOP, e alíquota do CMS.
             /// </summary>
             [SpedCampos(5, "VL_OPR", "N", 0, 2, true, 17)]
             public decimal VlOpr { get; set; }
@@ -3424,6 +3426,7 @@ namespace FiscalBr.EFDFiscal
             ///     Série do documento fiscal
             /// </summary>
             [SpedCampos(3, "SER", "C", 3, 0, true, 17)]
+            [SpedCampos(3, "SER", "N", 3, 0, true, 18)]
             public string Ser { get; set; }
 
             /// <summary>
@@ -3540,8 +3543,8 @@ namespace FiscalBr.EFDFiscal
             public decimal AliqIcms { get; set; }
 
             /// <summary>
-            ///     Valor total acumulado das operações correspondentes à combinação de CST_ICMS, CFOP e alíquota do ICMS, incluídas as
-            ///     despesas acessórias menos os descontos incondicionais. 
+            ///     Valor total dos itens relacionados aos serviços próprios com destaque de ICMS, correspondente à combinação de
+            ///     CST_ICMS, CFOP, e alíquota do ICMS.
             /// </summary>
             [SpedCampos(5, "VL_OPR", "N", 0, 2, true, 17)]
             public decimal VlOpr { get; set; }

--- a/src/FiscalBr.EFDFiscal/BlocoE.cs
+++ b/src/FiscalBr.EFDFiscal/BlocoE.cs
@@ -414,11 +414,11 @@ namespace FiscalBr.EFDFiscal
             }
 
             /// <summary>
-            ///     Código do participante
+            ///     Código do participante (campo 02 do Registro 0150)
             /// </summary>
             /// <remarks>
             ///     - do emitente do documento ou do remetente das mercadorias, no caso das entradas;
-            ///     - do adquirente, no caso de saídas
+            ///     - do adquirente, no caso de saídas.
             /// </remarks>
             [SpedCampos(2, "COD_PART", "C", 60, 0, true, 2)]
             public string CodPart { get; set; }
@@ -454,7 +454,7 @@ namespace FiscalBr.EFDFiscal
             public DateTime DtDoc { get; set; }
 
             /// <summary>
-            ///     Código do item
+            ///     Código do item (campo 02 do Registro 0200)
             /// </summary>
             [SpedCampos(8, "COD_ITEM", "C", 60, 0, false, 2)]
             public string CodItem { get; set; }
@@ -856,6 +856,12 @@ namespace FiscalBr.EFDFiscal
             /// </summary>
             [SpedCampos(9, "VL_AJ_ITEM", "N", 0, 2, true, 2)]
             public decimal VlAjItem { get; set; }
+
+            /// <summary>
+            ///     Chave do Documento Eletrônico
+            /// </summary>
+            [SpedCampos(9, "CHV_DOCe", "N", 44, 0, false, 18)]
+            public decimal ChvDoc { get; set; }
         }
 
         /// <summary>

--- a/tests/FiscalBr.Test/Sped/Bloco0/Bloco0Registro000Test.cs
+++ b/tests/FiscalBr.Test/Sped/Bloco0/Bloco0Registro000Test.cs
@@ -67,5 +67,39 @@
 
             Assert.Equal(expectedResult, currentResult);
         }
+
+        [Fact]
+        public void Escrever_Registro_0000_EFDFiscal_V18()
+        {
+            var initialDate = DateTime.Now.AddDays(-(DateTime.Now.Day - 1)).Date;
+            var finalDate = initialDate.AddMonths(1).AddDays(-1);
+
+            var formatedInitialDate = initialDate.ToString(new CultureInfo("pt-BR")).Replace("/", "").Split(" ")[0];
+            var formatedFinalDate = finalDate.ToString(new CultureInfo("pt-BR")).Replace("/", "").Split(" ")[0];
+
+            var expectedResult =
+                $"|0000|018|0|{formatedInitialDate}|{formatedFinalDate}|BANCO DO BRASIL S.A.|00000000000191||GO|123456789|5204508|||A|1|{Environment.NewLine}";
+
+            var source = new EFDFiscal.Bloco0.Registro0000
+            {
+                CodVer = CodVersaoSpedFiscal.V18,
+                CodFin = IndCodFinalidadeArquivo.RemessaArquivoOriginal,
+                DtIni = initialDate,
+                DtFin = finalDate,
+                Nome = "BANCO DO BRASIL S.A.",
+                Cnpj = "00000000000191",
+                Uf = "GO",
+                Ie = "123456789",
+                CodMun = "5204508",
+                IndPerfil = IndPerfilArquivo.A,
+                IndAtiv = Common.Sped.Enums.TipoAtivSpedFiscal.Outros
+            };
+
+            var efd = new ArquivoEFDFiscalV2(VersaoLeiauteSped.V18);
+
+            var currentResult = efd.EscreverLinha(source);
+
+            Assert.Equal(expectedResult, currentResult);
+        }
     }
 }

--- a/tests/FiscalBr.Test/Sped/Bloco1/Bloco1Registro1391Test.cs
+++ b/tests/FiscalBr.Test/Sped/Bloco1/Bloco1Registro1391Test.cs
@@ -12,7 +12,7 @@ namespace FiscalBr.Test.Sped.Bloco1
         [Fact]
         public void Ler_Registro_1391_EFDFiscal()
         {
-            string linha = "|1391|01012023|123,41|123,42|123,43|123,44|123,45|123,46|123,47|123,48|123,49|123,40|123,41|123,42|123,43|123,44|Observações|COD_ITEM|01|123,45|";
+            string linha = "|1391|01012023|123,41|123,42|123,43|123,44|123,45|123,46|123,47|123,48|123,49|123,40|123,41|123,42|123,43|123,44|Observações|COD_ITEM|01|123,45|123,45|123,45|123,45|";
 
             var registro = (FiscalBr.EFDFiscal.Bloco1.Registro1391)LerCamposSped.LerCampos(linha, "EFDFiscal", 0);
 

--- a/tests/FiscalBr.Test/Sped/Enums/CodigoVersaoLeiauteSpedTest.cs
+++ b/tests/FiscalBr.Test/Sped/Enums/CodigoVersaoLeiauteSpedTest.cs
@@ -95,7 +95,7 @@ namespace FiscalBr.Test.Sped.Enums
 
         [Theory]
         [InlineData(VersaoLeiauteSped.V2, CodVersaoSpedFiscal.V2)]
-        [InlineData(null, CodVersaoSpedFiscal.V17)]
+        [InlineData(null, CodVersaoSpedFiscal.V18)]
         public void ObterEnumVersaoEFDFiscalTest(VersaoLeiauteSped? v, CodVersaoSpedFiscal? resultadoEsperado)
         {
             var maiorVersao = (int)EnumHelpers.GetEnumMaxValue<CodVersaoSpedFiscal>();
@@ -141,7 +141,7 @@ namespace FiscalBr.Test.Sped.Enums
         }
 
         [Theory]
-        [InlineData(16)]
+        [InlineData(17)]
         public void ObterNumeroVersoesEFDFiscalTest(int qtdEsperada)
         {
             var efd = new ArquivoEFDFiscalV2();


### PR DESCRIPTION
**Descrição:**
- Adicionado enum V18 nas lista des emums "VersaoLeiauteSped" e "CodVersaoSpedFiscal";
- Adicionado enum "RecusaDeRecebimento" na lista de enums "IndTipoOperacaoStUfDiversa";
- Adicionado a versão 18 do EFD ICMS IPI no método ObterEnumVersaoLeiaute da classe ArquivoSpedV2.cs;
- Adicionados os campos 21 a 23 no Registro 1391 (QTD_RESIDUO_DDG, QTD_RESIDUO_WDG e QTD_RESIDUO_CANA). Foi corrigido também o campo 20, que estava sendo informado como campo 19, gerando duplicidade de campos no Registro;
- Adicionado nos campos 7 e 22 do registro D700 a nova obrigatoriedade de preenchimento;
- Adicionado no campo 3 do registro D750 a nova obrigatoriedade de preenchimento;
- Adicionado campo 9 (CHV_DOCe) no Registro E240;
- Adicionado teste "Escrever_Registro_0000_EFDFiscal_V18" na classe "Bloco0Registro000Test";
- Adicionados os novos campos do registro 1391 no teste "Ler_Registro_1391_EFDFiscal" na classe "Bloco1Registro1391Test";
- Adicionado a versão 18 nos testes "ObterNumeroVersoesEFDFiscalTest" e "ObterEnumVersaoEFDFiscalTest" da classe "CodigoVersaoLeiauteSpedTest".

**Issue(s) relacionada(s):**
Issue relacionada: #107 

**Check list:**
- [ ] Marque se alterações na Wiki do projeto serão necessárias.
- [x] Marque se os testes foram adicionados e/ou atualizados após as alterações.
