### PR TITLE
Alterado quantidade de casas decimais do K235 no campo QTD

### DIFF
--- a/src/FiscalBr.EFDFiscal/BlocoK.cs
+++ b/src/FiscalBr.EFDFiscal/BlocoK.cs
@@ -349,7 +349,7 @@ namespace FiscalBr.EFDFiscal
             /// <summary>
             ///     Quantidade consumida do item
             /// </summary>
-            [SpedCampos(4, "QTD", "N", 0, 3, true, 10)]
+            [SpedCampos(4, "QTD", "N", 0, 6, true, 10)]
             public decimal Qtd { get; set; }
 
             /// <summary>


### PR DESCRIPTION
**Descrição:**
Ajustado quantidade de casas decimais para o campo QTD no registro K235, conforme nova atualização.

**Check list:**
- [ ] Marque se alterações na Wiki do projeto serão necessárias.
- [ ] Marque se os testes foram adicionados e/ou atualizados após as alterações.
