### PR TITLE
fix: type to int

### DIFF
--- a/src/FiscalBr.EFDContribuicoes/BlocoD.cs
+++ b/src/FiscalBr.EFDContribuicoes/BlocoD.cs
@@ -990,7 +990,7 @@ namespace FiscalBr.EFDContribuicoes
             ///     Código da situação do documento fiscal, conforme a Tabela 4.1.2
             /// </summary>
             [SpedCampos(6, "COD_SIT", "N", 2, 0, true, 2)]
-            public decimal CodSit { get; set; }
+            public int CodSit { get; set; }
 
             /// <summary>
             ///     Série do documento fiscal


### PR DESCRIPTION
Realizada a alteração do tipo da propriedade CodSit (Campo 06) do bloco D500 de decimal para int pois não está gerando a linha do bloco corretamente. Está gerando com 1 caractere somente e deveria ser gerada com 2 caracteres conforme o manual.

Campo 06 - Valores válidos: [00, 01, 02, 03, 06, 07, 08] 
