### PR TITLE
Corrigido tipo, tamanho e quantidade de casas decimais do campo QTD_DEST no registro K220

### DIFF
--- a/src/FiscalBr.EFDFiscal/BlocoK.cs
+++ b/src/FiscalBr.EFDFiscal/BlocoK.cs
@@ -268,11 +268,11 @@ namespace FiscalBr.EFDFiscal
 
             /// <summary>
             ///     Quantidade movimentada do item de destino
-            ///     Guia Prático EFD-ICMS/IPI – Versão 2.0.21
-            ///     Atualização: 22/08/2017
+            ///     Guia Prático EFD-ICMS/IPI – Versão 3.1.8
+            ///     Atualização: 31/10/2024
             /// </summary>
-            [SpedCampos(6, "QTD_DEST", "N", 3, 0, false, 10)]
-            public string QtdDest { get; set; }
+            [SpedCampos(6, "QTD_DEST", "N", 0, 6, false, 10)]
+            public decimal QtdDest { get; set; }
         }
 
         /// <summary>


### PR DESCRIPTION
**Descrição:**
Corrigido tipo do campo QTD_DEST  no registro K220 de string para decimal;
Corrigido quantidade de casas decimais  do campo QTD_DEST  no registro K220 de 0 para 6;
Corrigido quantidade do campo QTD_DEST  no registro K220 de 3 para 0;
Ajustado data da versão e atualização do leiaute.

**Issue(s) relacionada(s):**
Adicione o link da(s) issue(s) relacionada(s) - caso exista(m).

**Check list:**
- [ ] Marque se alterações na Wiki do projeto serão necessárias.
- [ ] Marque se os testes foram adicionados e/ou atualizados após as alterações.
